### PR TITLE
Added setter for audio stream

### DIFF
--- a/speech/src/main/java/net/gotev/speech/Speech.java
+++ b/speech/src/main/java/net/gotev/speech/Speech.java
@@ -54,6 +54,7 @@ public class Speech {
     private int mTtsQueueMode = TextToSpeech.QUEUE_FLUSH;
     private long mStopListeningDelayInMs = 4000;
     private long mTransitionMinimumDelay = 1200;
+    private int mAudioStream = TextToSpeech.Engine.DEFAULT_STREAM;
     private long mLastActionTimestamp;
     private List<String> mLastPartialResults = null;
 
@@ -501,9 +502,12 @@ public class Speech {
         }
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            mTextToSpeech.speak(message, mTtsQueueMode, null, utteranceId);
+            final Bundle params = new Bundle();
+            params.putString(TextToSpeech.Engine.KEY_PARAM_STREAM, String.valueOf(mAudioStream));
+            mTextToSpeech.speak(message, mTtsQueueMode, params, utteranceId);
         } else {
             final HashMap<String, String> params = new HashMap<>();
+            params.put(TextToSpeech.Engine.KEY_PARAM_STREAM, String.valueOf(mAudioStream));
             params.put(TextToSpeech.Engine.KEY_PARAM_UTTERANCE_ID, utteranceId);
             mTextToSpeech.speak(message, mTtsQueueMode, params);
         }
@@ -619,6 +623,21 @@ public class Speech {
      */
     public Speech setTextToSpeechQueueMode(final int mode) {
         mTtsQueueMode = mode;
+        return this;
+    }
+
+
+    /**
+     * Sets the audio stream type.
+     * By default is TextToSpeech.Engine.DEFAULT_STREAM, which is equivalent to
+     * AudioManager.STREAM_MUSIC.
+     *
+     * @param audioStream A constant from AudioManager.
+     *                    e.g. {@link android.media.AudioManager#STREAM_VOICE_CALL}
+     * @return speech instance
+     */
+    public Speech setAudioStream(final int audioStream){
+        mAudioStream = audioStream;
         return this;
     }
 


### PR DESCRIPTION
Added enhancement to allow caller to set the audio stream of TTS calls. 
This is useful for allows TTS in non-default streams, such as on bluetooth devices. 

## Changes Summary: 
- Default audio stream: `TextToSpeech.Engine.DEFAULT_STREAM`
- Added `setAudioStream` method.
